### PR TITLE
Allow blocking CVEs from irrelevant products

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,26 @@ Generate a Markdown report with information about your dependencies
 myprecious help
 ```
 
+## Configuration
+
+### CVE Vendor Blocking
+
+Because the search for CVEs in NIST's NVD can turn up false-positive matches, especially for dependencies with generic names like "mail", myprecious can be configured to ignore CVEs whose CPEs identify particular vendor/product pairs.  To do this, a file named `.myprecious-cves.rb` must be put in the same directory as the target project's package configuration (either the current directory or specified with the `-C`/`--dir` option).  That file must be a Ruby file that outputs JSON to STDOUT.  An example would be:
+
+```ruby
+require 'json'
+
+JSON.dump({
+  blockedProducts: %w[
+    apple:mail
+    basercms:mail
+    downline_goldmine:builder
+  ],
+}, $stdout)
+```
+
+Each entry in `blockedProducts` should be a *vendor:product* pair, just as it would appear in the irrelevant CPE(s).
+
 ## Installing bash completions
 
 Run the `myprecious` executable file with the `--install-completions` flag.  It will both install completions for bash session launched in the future and provide the path to the bash script that can be `source`ed in any existing bash sessions to enable completion.  This command only needs to be run once.

--- a/lib/myprecious.rb
+++ b/lib/myprecious.rb
@@ -13,6 +13,7 @@ module MyPrecious
   ONE_DAY = 60 * 60 * 24
 end
 require 'myprecious/data_caches'
+require 'myprecious/cves'
 
 module MyPrecious
   extend Rake::DSL
@@ -38,6 +39,7 @@ module MyPrecious
       fpath = Pathname(fpath)
       parser.invalid_args!("#{fpath} does not exist.") unless fpath.exist?
       args.target = fpath
+      CVEs.config_dir = fpath
     end
     
     parser.on(

--- a/lib/myprecious/cves.rb
+++ b/lib/myprecious/cves.rb
@@ -2,6 +2,8 @@ require 'date'
 require 'digest'
 require 'json'
 require 'myprecious/data_caches'
+require 'open3'
+require 'pathname'
 require 'rest-client'
 require 'set'
 
@@ -10,8 +12,17 @@ module MyPrecious
     extend DataCaching
     
     MIN_GAP_SECONDS = 5
+    CONFIG_FILE = '.myprecious-cves.rb'
     
     CVE_DATA_CACHE_DIR = MyPrecious.data_cache(DATA_DIR / "cve-data")
+    
+    class <<self
+      attr_reader :config_dir
+      
+      def config_dir=(val)
+        @config_dir = Pathname(val)
+      end
+    end
     
     def self.last_query_time
       @last_query_time ||= DateTime.now - 1
@@ -57,11 +68,36 @@ module MyPrecious
           )
           
           [cve, applicability]
-        end
+        end.reject {|cve, a| a.respond_to?(:applies_to?) && !a.applies_to?(version)}
       rescue StandardError => e
         $stderr.puts "[WARN] #{e}\n\n#{response.body}\n\n"
         []
       end
+    end
+    
+    def self.config
+      if !@config && config_dir
+        if (config_path = config_dir / CONFIG_FILE).exist?
+          @config = begin
+            config_prog_output, status = Open3.capture2(RbConfig.ruby, config_path.to_s)
+            if status.success?
+              JSON.parse(config_prog_output)
+            else
+              $stderr.puts "#{config_path} did not exit cleanly (code ${status.exitstatus})"
+              {}
+            end
+          rescue StandardError
+          end
+          
+          unless @config.kind_of?(Hash)
+            $stderr.puts "#{config_path} did not output a JSON configuration"
+            @config = {}
+          end
+        else
+          @config = {}
+        end
+      end
+      @config
     end
     
     def self.objectify_configurations(package_name, configs)
@@ -141,7 +177,6 @@ module MyPrecious
       def version_matches_node?(version, node)
         test = (node['operator'] == 'AND') ? :all? : :any?
         if node['children']
-          return node['children']
           return node['children'].send(test) {|child| version_matches_node?(version, child)}
         end
         
@@ -153,7 +188,12 @@ module MyPrecious
       def cpe_entry_indicates_vulnerable_version?(version, pattern)
         return false unless pattern['vulnerable']
         
-        cpe_version, cpe_update = pattern['cpe23Uri'].split(':')[5,2]
+        cpe_vendor, cpe_product, cpe_version, cpe_update = pattern['cpe23Uri'].split(':')[3,4]
+        return false if (CVEs.config['blockedProducts'] ||= []).include?([cpe_vendor, cpe_product].join(':'))
+        return false if cpe_product != @package
+        if version == '*'
+          return true
+        end
         return false unless [nil, '*', '-'].include?(cpe_update) # We'll ignore prerelease versions
         if cpe_version != '*' && cpe_version == version
           return true


### PR DESCRIPTION
There is no automated way to identify the correct "vendor" for these
dependency packages in NIST's NVD when querying for CVEs.  Add a way
to configure a list of vendors/product pairs known to be irrelevant.