### PR TITLE
Fix expired cert placehold url

### DIFF
--- a/lib/myprecious.rb
+++ b/lib/myprecious.rb
@@ -607,7 +607,7 @@ module MyPrecious
     # Sourced from: https://stackoverflow.com/a/41247934
     #
     def color_swatch
-      "![##{color}](https://placehold.it/15/#{color}/000000?text=+)"
+      "![##{color}](https://placehold.co/15/#{color}/000000?text=+)"
     end
     
     ##


### PR DESCRIPTION
Hello!

.it is no longer valid. 
.co seems to work.