### PR TITLE
One more url placehold change

### DIFF
--- a/lib/myprecious.rb
+++ b/lib/myprecious.rb
@@ -607,7 +607,7 @@ module MyPrecious
     # Sourced from: https://stackoverflow.com/a/41247934
     #
     def color_swatch
-      "![##{color}](https://placehold.co/15/#{color}/000000?text=+)"
+      "![##{color}](https://placehold.co/15/#{color}/000000?text=.)"
     end
     
     ##


### PR DESCRIPTION
😄  One more change if you don't mind

'+' is no longer working and the size of the image now shows. So we were thinking a '.' instead.


[original placehold link](https://placehold.co/15/4dda1b/000000?text=+)


vs.

[new placehold link with '.'](https://placehold.co/15/4dda1b/000000?text=.)


Thank you Balki!